### PR TITLE
Simplify cd alias to not require separate function

### DIFF
--- a/zsh/zshrc.sh
+++ b/zsh/zshrc.sh
@@ -6,19 +6,12 @@
 
 # Aliases
 	alias v="vim -p"
+	alias cd='cd $1 && ls'
 
 # Settings
 	export VISUAL=vim
 
 source ~/dotfiles/zsh/plugins/fixls.zsh
-
-#Functions
-	# Custom cd
-	c() {
-		cd $1;
-		ls;
-	}
-	alias cd="c"
 
 # For vim mappings: 
 	stty -ixon


### PR DESCRIPTION
As it was, the alias code for cd unnecessarily relied upon a separate function. Now it doesn't.