### PR TITLE
Simplify prompt

### DIFF
--- a/zsh/prompt.sh
+++ b/zsh/prompt.sh
@@ -10,7 +10,7 @@ set_prompt() {
 	PS1="["
 
 	# Path: http://stevelosh.com/blog/2010/02/my-extravagant-zsh-prompt/
-	PS1+="%{$fg_bold[blue]%}${PWD/#$HOME/~}%{$reset_color%}"
+	PS1+="%{$fg_bold[blue]%}%~%{$reset_color%}"
 
 	# Status Code
 	PS1+='%(?.., %{$fg[red]%}%?%{$reset_color%})'


### PR DESCRIPTION
Simplify prompt with the built-in special characteristic `%~`, which can also be shortened to `n` number of folders deep with `%n~`.